### PR TITLE
fix: the readme and train codes do not match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.pyc
+
+
+.vscode
+experiments
+pretrain_models

--- a/README.md
+++ b/README.md
@@ -9,10 +9,17 @@ This repository contains the source code and dataset for the paper: **PRGC: Pote
 
 The main requirements are:
 
-  - python==3.7.9
-  - pytorch==1.6.0
-  - transformers==3.2.0
-  - tqdm
+```
+tqdm==4.59.0
+transformers==3.2.0
+torch==1.9.0
+torchaudio==0.9.0
+torchvision==0.10.0
+```
+
+You can run in terminal:`pip install -r requirements.txt`
+or (国内请使用=>)`pip install -i https://pypi.douban.com/simple -r requirements.txt`
+
 
 ## Datasets
 
@@ -26,7 +33,7 @@ Or you can just download our preprocessed [datasets](https://drive.google.com/fi
 
 **1. Get pre-trained BERT model for PyTorch**
 
-Download [BERT-Base-Cased](https://huggingface.co/bert-base-cased/tree/main) which contains `pytroch_model.bin`, `vocab.txt` and `config.json`. Put these under `./pretrain_models`.
+Download [BERT-Base-Cased](https://huggingface.co/bert-base-cased/tree/main) which contains `pytroch_model.bin`, `vocab.txt` and `config.json`. Put these under `./pretrain_models/bert_base_cased/`.
 
 **2. Build Data**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+tqdm==4.59.0
+transformers==3.2.0
+torch==1.9.0
+torchaudio==0.9.0
+torchvision==0.10.0

--- a/train.py
+++ b/train.py
@@ -213,7 +213,8 @@ if __name__ == '__main__':
     logging.info("device: {}".format(params.device))
 
     logging.info('Load pre-train model weights...')
-    bert_config = BertConfig.from_json_file(os.path.join(params.bert_model_dir, 'bert_config.json'))
+    bert_config = BertConfig.from_json_file(os.path.join(params.bert_model_dir, 'config.json'))
+
     model = BertForRE.from_pretrained(config=bert_config,
                                       pretrained_model_name_or_path=params.bert_model_dir,
                                       params=params)


### PR DESCRIPTION
```
Download [BERT-Base-Cased](https://huggingface.co/bert-base-cased/tree/main) which contains `pytroch_model.bin`, `vocab.txt` and `config.json`. Put these under `./pretrain_models/`.
```

👆🏻👆🏻👆🏻Above will display an error, do not have this folder(/pretrain_models/bert_base_cased/)


```
# in train.py

bert_config = BertConfig.from_json_file(os.path.join(params.bert_model_dir, 'bert_config.json'))
```

👆🏻👆🏻👆🏻Above will display an error, can't find bert_config.json.In fact just download should be config.json
